### PR TITLE
[webview_flutter] Fix file chooser AlertDialog.Builder displays blank on certain devices.

### DIFF
--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.8.3+3
+
+* Fixes file chooser AlertDialog.Builder displays blank on certain devices.
 ## 2.8.3+2
 
 * fix flutter analyze issues

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebChromeClientHostApiImpl.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebChromeClientHostApiImpl.java
@@ -252,7 +252,7 @@ public class WebChromeClientHostApiImpl implements WebChromeClientHostApi {
     }
     String[] selectPicTypeStr = {WebViewFlutterPlugin.activity.getString(R.string.take_photo),
             WebViewFlutterPlugin.activity.getString(R.string.photo_library)};
-    new AlertDialog.Builder(WebViewFlutterPlugin.activity)
+    new AlertDialog.Builder(WebViewFlutterPlugin.activity, AlertDialog.THEME_DEVICE_DEFAULT_DARK)
             .setOnCancelListener(new ReOnCancelListener())
             .setItems(selectPicTypeStr,
                     new DialogInterface.OnClickListener() {

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_pro_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/wenzhiming/flutter-plugins/tree/main/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/wenzhiming/flutter-plugins/issues
-version: 2.8.3+2
+version: 2.8.3+3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
*I've fixed an issue that was causing AlertDialog.Builder to display blank on certain devices (such as Xiaomi that use certain versions of MIUI), unless a theme is supplied through the second param. [See the fix here](https://github.com/Wifft/flutter-plugins/commit/a3ffba5d33fec30db6de7f9aabc7c29266117d71#diff-6f7ba369445756470028513ab0ad6a7dae5ee15648350f6064b6fb8ecd97a9cd).
The fix is based on this [StackOverflow thread](https://stackoverflow.com/questions/37848698/android-alertdialog-builder-displays-blank-unless-a-theme-is-supplied). The issue was happening because some devices renders the text and background colors of the default AlertDialog withe, so makes it invisible. 
My fix enforces the use of the default dark theme of the device.
**Note**: I'm aware that the use of the  constant `AlertDialog.THEME_DEVICE_DEFAULT_DARK` is deprecated since the API level 23, in favour of **[R.style.Theme_DeviceDefault_Light_Dialog_Alert](https://developer.android.com/reference/android/R.style#Theme_DeviceDefault_Light_Dialog_Alert)** but I don't want to incrase the minium requirements of this plugin.*

Before the fix:
![Before](https://fv9-4.failiem.lv/thumb_show.php?i=g63737w3y&view)

After the fix:
![After](https://fv9-5.failiem.lv/thumb_show.php?i=fc94xra5n&view)

*This PR fixes an issue that causes a file chooser AlertDialog.Builder to display blank on certain devices.*

*No tests added or changed*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests